### PR TITLE
[#29] [UI] As a user, I can see text area answer

### DIFF
--- a/integration_test/survey_questions_screen_test.dart
+++ b/integration_test/survey_questions_screen_test.dart
@@ -23,6 +23,7 @@ void surveyQuestionsScreenTest() {
     late Finder answerEmoji;
     late Finder answerSmiley;
     late Finder answerNps;
+    late Finder answerTextArea;
 
     setUpAll(() async {
       await TestUtil.setupTestEnvironment();
@@ -41,6 +42,7 @@ void surveyQuestionsScreenTest() {
       answerEmoji = find.byKey(SurveyQuestionsWidgetId.answersEmoji);
       answerSmiley = find.byKey(SurveyQuestionsWidgetId.answersSmiley);
       answerNps = find.byKey(SurveyQuestionsWidgetId.answersNps);
+      answerTextArea = find.byKey(SurveyQuestionsWidgetId.answersTextArea);
     });
 
     Future nextQuestionTest(
@@ -80,6 +82,7 @@ void surveyQuestionsScreenTest() {
       expect(answerEmoji, findsNothing);
       expect(answerSmiley, findsNothing);
       expect(answerNps, findsNothing);
+      expect(answerTextArea, findsNothing);
     });
 
     testWidgets(
@@ -125,46 +128,55 @@ void surveyQuestionsScreenTest() {
       await answerTest(answerDropdown, findsNothing);
       await answerTest(answerEmoji, findsNothing);
       await answerTest(answerNps, findsNothing);
+      await answerTest(answerTextArea, findsNothing);
 
       await nextQuestionTest(tester, '3/12');
       await answerTest(answerDropdown, findsNothing);
       await answerTest(answerEmoji, findsNothing);
       await answerTest(answerNps, findsNothing);
+      await answerTest(answerTextArea, findsNothing);
 
       await nextQuestionTest(tester, '4/12');
       await answerTest(answerDropdown, findsNothing);
       await answerTest(answerEmoji, findsNothing);
       await answerTest(answerNps, findsOneWidget);
+      await answerTest(answerTextArea, findsNothing);
 
       await nextQuestionTest(tester, '5/12');
       await answerTest(answerDropdown, findsNothing);
       await answerTest(answerEmoji, findsOneWidget);
       await answerTest(answerNps, findsNothing);
+      await answerTest(answerTextArea, findsNothing);
 
       await nextQuestionTest(tester, '6/12');
       await answerTest(answerDropdown, findsNothing);
       await answerTest(answerEmoji, findsOneWidget);
       await answerTest(answerNps, findsNothing);
+      await answerTest(answerTextArea, findsNothing);
 
       await nextQuestionTest(tester, '7/12');
       await answerTest(answerDropdown, findsNothing);
       await answerTest(answerEmoji, findsOneWidget);
       await answerTest(answerNps, findsNothing);
+      await answerTest(answerTextArea, findsNothing);
 
       await nextQuestionTest(tester, '8/12');
       await answerTest(answerDropdown, findsNothing);
       await answerTest(answerEmoji, findsOneWidget);
       await answerTest(answerNps, findsNothing);
+      await answerTest(answerTextArea, findsNothing);
 
       await nextQuestionTest(tester, '9/12');
       await answerTest(answerDropdown, findsNothing);
       await answerTest(answerEmoji, findsNothing);
       await answerTest(answerNps, findsNothing);
+      await answerTest(answerTextArea, findsOneWidget);
 
       await nextQuestionTest(tester, '10/12');
       await answerTest(answerDropdown, findsOneWidget);
       await answerTest(answerEmoji, findsNothing);
       await answerTest(answerNps, findsNothing);
+      await answerTest(answerTextArea, findsNothing);
     });
   });
 }

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -10,5 +10,7 @@
   "survey_details_start_survey_button": "Start survey",
 
   "survey_question_nps_lowest_description": "Not at all Likely",
-  "survey_question_nps_highest_description": "Extremely Likely"
+  "survey_question_nps_highest_description": "Extremely Likely",
+
+  "survey_question_textarea_hint": "Your thoughts"
 }

--- a/lib/ui/questions/survey_answer_view.dart
+++ b/lib/ui/questions/survey_answer_view.dart
@@ -7,6 +7,7 @@ import 'package:survey_flutter_ic/ui/questions/survey_questions_widget_id.dart';
 import 'package:survey_flutter_ic/widget/answer_dropdown.dart';
 import 'package:survey_flutter_ic/widget/answer_emoji.dart';
 import 'package:survey_flutter_ic/widget/answer_nps.dart';
+import 'package:survey_flutter_ic/widget/answer_textarea.dart';
 
 class SurveyAnswerView extends ConsumerStatefulWidget {
   final SurveyQuestionUiModel question;
@@ -49,6 +50,11 @@ class _SurveyAnswerViewState extends ConsumerState<SurveyAnswerView> {
           onAnswerSelected: (answer) {
             widget.onAnswerSelected.call(answer);
           },
+        );
+      case QuestionDisplayType.textarea:
+        // TODO: Handle filled text area
+        return AnswerTextarea(
+          answers: question.answers,
         );
       default:
         return const SizedBox.shrink();

--- a/lib/ui/questions/survey_questions_screen.dart
+++ b/lib/ui/questions/survey_questions_screen.dart
@@ -4,6 +4,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_svg/flutter_svg.dart';
 import 'package:go_router/go_router.dart';
+import 'package:survey_flutter_ic/extension/context_extension.dart';
 import 'package:survey_flutter_ic/gen/assets.gen.dart';
 import 'package:survey_flutter_ic/theme/dimens.dart';
 import 'package:survey_flutter_ic/ui/details/survey_details_ui_model.dart';
@@ -88,17 +89,20 @@ class _SurveyQuestionsScreenScreenState
                 colors: [Colors.black12, Colors.black26],
               ),
             ),
-            child: SafeArea(
-              child: Column(
-                crossAxisAlignment: CrossAxisAlignment.start,
-                children: [
-                  _buildCloseSurveyButton(),
-                  _buildQuestionIndicator(visibleIndex, totalQuestions),
-                  const SizedBox(height: space8),
-                  _buildQuestionsView(surveyDetails.questions),
-                  _buildNextQuestionButton(visibleIndex, totalQuestions),
-                  const SizedBox(height: space57)
-                ],
+            child: GestureDetector(
+              onTap: () => context.hideKeyboard(),
+              child: SafeArea(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    _buildCloseSurveyButton(),
+                    _buildQuestionIndicator(visibleIndex, totalQuestions),
+                    const SizedBox(height: space8),
+                    _buildQuestionsView(surveyDetails.questions),
+                    _buildNextQuestionButton(visibleIndex, totalQuestions),
+                    const SizedBox(height: space57)
+                  ],
+                ),
               ),
             ),
           ),

--- a/lib/ui/questions/survey_questions_screen.dart
+++ b/lib/ui/questions/survey_questions_screen.dart
@@ -45,6 +45,7 @@ class _SurveyQuestionsScreenScreenState
   Widget build(BuildContext context) {
     final state = ref.watch(surveyQuestionsViewModelProvider);
     return Scaffold(
+      resizeToAvoidBottomInset: false,
       body: state.maybeWhen(
         loading: () => _buildLoadingIndicator(),
         success: (surveyDetails) => _buildSurveyQuestionsContent(surveyDetails),

--- a/lib/ui/questions/survey_questions_widget_id.dart
+++ b/lib/ui/questions/survey_questions_widget_id.dart
@@ -13,4 +13,5 @@ class SurveyQuestionsWidgetId {
   static const answersEmoji = Key('answersEmoji');
   static const answersSmiley = Key('answersSmiley');
   static const answersNps = Key('answersNps');
+  static const answersTextArea = Key('answersTextArea');
 }

--- a/lib/widget/answer_textarea.dart
+++ b/lib/widget/answer_textarea.dart
@@ -1,0 +1,50 @@
+import 'package:flutter/material.dart';
+import 'package:survey_flutter_ic/extension/context_extension.dart';
+import 'package:survey_flutter_ic/theme/dimens.dart';
+import 'package:survey_flutter_ic/ui/questions/survey_answer_ui_model.dart';
+
+class AnswerTextarea extends StatefulWidget {
+  final List<SurveyAnswerUiModel> answers;
+
+  const AnswerTextarea({Key? key, required this.answers}) : super(key: key);
+
+  @override
+  State<AnswerTextarea> createState() => _AnswerTextareaState();
+}
+
+class _AnswerTextareaState extends State<AnswerTextarea> {
+  @override
+  Widget build(BuildContext context) {
+    return Expanded(
+      child: Container(
+        decoration: BoxDecoration(
+          color: Colors.white.withOpacity(0.2),
+          borderRadius: BorderRadius.circular(borderRadius10),
+        ),
+        child: TextField(
+          maxLines: null,
+          keyboardType: TextInputType.multiline,
+          textAlign: TextAlign.start,
+          cursorColor: Colors.white,
+          style: const TextStyle(
+            color: Colors.white,
+            fontSize: fontSize17,
+            fontWeight: FontWeight.w400,
+          ),
+          decoration: InputDecoration(
+            border: InputBorder.none,
+            hintText: context.localization.survey_question_textarea_hint,
+            hintStyle: TextStyle(
+              color: Colors.white.withOpacity(0.3),
+              fontSize: fontSize17,
+            ),
+            contentPadding: const EdgeInsets.symmetric(
+              horizontal: space10,
+              vertical: space18,
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/widget/answer_textarea.dart
+++ b/lib/widget/answer_textarea.dart
@@ -24,7 +24,7 @@ class _AnswerTextareaState extends State<AnswerTextarea> {
           borderRadius: BorderRadius.circular(borderRadius10),
         ),
         child: TextField(
-          maxLines: null,
+          maxLines: 5,
           keyboardType: TextInputType.multiline,
           textAlign: TextAlign.start,
           cursorColor: Colors.white,

--- a/lib/widget/answer_textarea.dart
+++ b/lib/widget/answer_textarea.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:survey_flutter_ic/extension/context_extension.dart';
 import 'package:survey_flutter_ic/theme/dimens.dart';
 import 'package:survey_flutter_ic/ui/questions/survey_answer_ui_model.dart';
+import 'package:survey_flutter_ic/ui/questions/survey_questions_widget_id.dart';
 
 class AnswerTextarea extends StatefulWidget {
   final List<SurveyAnswerUiModel> answers;
@@ -16,6 +17,7 @@ class _AnswerTextareaState extends State<AnswerTextarea> {
   @override
   Widget build(BuildContext context) {
     return Expanded(
+      key: SurveyQuestionsWidgetId.answersTextArea,
       child: Container(
         decoration: BoxDecoration(
           color: Colors.white.withOpacity(0.2),


### PR DESCRIPTION
Close https://github.com/hoangnguyen92dn/survey-flutter-ic/issues/29

## What happened 👀

- Display a textbox that supports multi-line text input
  - Display a placeholder inside the textbox
  - The textbox is scrollable when the number of lines goes beyond its viewport (i.e., when the text input no longer fits within the textbox)
- Display the keyboard when a textbox is selected
  - Tap anywhere outside of textbox to release the keyboard
  - The keyboard must not cover what the user is typing

## Insight 📝

- Add Answer Textarea UI
- Hide soft input keyboard on touch outside
- Add UnitTest

## Proof Of Work 📹

https://user-images.githubusercontent.com/6950766/231940805-edac5809-039a-474e-b541-08494426b7fc.mp4

Integration test passed ✅ 
![image](https://user-images.githubusercontent.com/6950766/231939977-29ae6714-5459-49e1-9cdf-c2a227850a7d.png)
