### PR TITLE
[#11][Backend] As a user, I can sign out

### DIFF
--- a/lib/api/repository/auth_repository.dart
+++ b/lib/api/repository/auth_repository.dart
@@ -1,4 +1,5 @@
 import 'package:injectable/injectable.dart';
+import 'package:survey_flutter_ic/api/request/sign_out_request.dart';
 
 import '../../env.dart';
 import '../../model/auth_model.dart';
@@ -18,6 +19,10 @@ abstract class AuthRepository {
 
   Future<AuthModel> refreshToken({
     required String refreshToken,
+  });
+
+  Future<void> signOut({
+    required String token,
   });
 }
 
@@ -60,6 +65,22 @@ class AuthRepositoryImpl extends AuthRepository {
         ),
       );
       return AuthModel.fromResponse(response);
+    } catch (exception) {
+      throw NetworkExceptions.fromDioException(exception);
+    }
+  }
+
+  @override
+  Future<void> signOut({required String token}) async {
+    try {
+      final response = await _authService.signOut(
+        SignOutRequest(
+          token: token,
+          clientId: Env.clientId,
+          clientSecret: Env.clientSecret,
+        ),
+      );
+      return response;
     } catch (exception) {
       throw NetworkExceptions.fromDioException(exception);
     }

--- a/lib/api/request/sign_out_request.dart
+++ b/lib/api/request/sign_out_request.dart
@@ -1,0 +1,21 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'sign_out_request.g.dart';
+
+@JsonSerializable()
+class SignOutRequest {
+  final String token;
+  final String clientId;
+  final String clientSecret;
+
+  SignOutRequest({
+    required this.token,
+    required this.clientId,
+    required this.clientSecret,
+  });
+
+  factory SignOutRequest.fromJson(Map<String, dynamic> json) =>
+      _$SignOutRequestFromJson(json);
+
+  Map<String, dynamic> toJson() => _$SignOutRequestToJson(this);
+}

--- a/lib/api/service/auth_service.dart
+++ b/lib/api/service/auth_service.dart
@@ -1,5 +1,7 @@
 import 'package:dio/dio.dart';
 import 'package:retrofit/http.dart';
+import 'package:survey_flutter_ic/api/request/sign_out_request.dart';
+
 import '../request/refresh_token_request.dart';
 import '../request/sign_in_request.dart';
 import '../response/auth_response.dart';
@@ -13,6 +15,10 @@ abstract class AuthService {
 
   Future<AuthResponse> refreshToken(
     @Body() RefreshTokenRequest body,
+  );
+
+  Future<void> signOut(
+    @Body() SignOutRequest body,
   );
 }
 
@@ -30,5 +36,11 @@ abstract class AuthServiceImpl extends AuthService {
   @POST('/api/v1/oauth/token')
   Future<AuthResponse> refreshToken(
     @Body() RefreshTokenRequest body,
+  );
+
+  @override
+  @POST('/api/v1/oauth/revoke')
+  Future<void> signOut(
+    @Body() SignOutRequest body,
   );
 }

--- a/lib/usecase/sign_out_use_case.dart
+++ b/lib/usecase/sign_out_use_case.dart
@@ -1,0 +1,27 @@
+import 'dart:async';
+
+import 'package:injectable/injectable.dart';
+import 'package:survey_flutter_ic/api/exception/network_exceptions.dart';
+import 'package:survey_flutter_ic/api/persistence/auth_persistence.dart';
+import 'package:survey_flutter_ic/usecase/base/base_use_case.dart';
+
+import '../api/repository/auth_repository.dart';
+
+@Injectable()
+class SignOutUseCase extends NoParamsUseCase<void> {
+  final AuthRepository _repository;
+  final AuthPersistence _persistence;
+
+  const SignOutUseCase(this._repository, this._persistence);
+
+  @override
+  Future<Result<void>> call() async {
+    final token = await _persistence.accessToken ?? '';
+    return _repository
+        .signOut(token: token)
+        // ignore: unnecessary_cast
+        .then((token) => Success(null) as Result<void>)
+        .onError<NetworkExceptions>(
+            (exception, stackTrace) => Failed(UseCaseException(exception)));
+  }
+}

--- a/test/api/repository/auth_repository_test.dart
+++ b/test/api/repository/auth_repository_test.dart
@@ -1,10 +1,11 @@
 import 'package:flutter_config/flutter_config.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mockito/mockito.dart';
 import 'package:survey_flutter_ic/api/exception/network_exceptions.dart';
 import 'package:survey_flutter_ic/api/repository/auth_repository.dart';
 import 'package:survey_flutter_ic/api/response/auth_response.dart';
 import 'package:survey_flutter_ic/model/auth_model.dart';
-import 'package:flutter_test/flutter_test.dart';
-import 'package:mockito/mockito.dart';
+
 import '../../mocks/generate_mocks.mocks.dart';
 
 void main() {
@@ -48,6 +49,57 @@ void main() {
       when(mockAuthService.signIn(any)).thenThrow(MockDioError());
 
       result() => repository.signIn(email: 'email', password: 'password');
+
+      expect(result, throwsA(isA<NetworkExceptions>()));
+    });
+
+    test(
+        'When calling refreshToken successfully, it emits the corresponding response',
+        () async {
+      final response = AuthResponse(
+        accessToken: 'accessToken',
+        tokenType: 'tokenType',
+        expiresIn: 0,
+        refreshToken: 'refreshToken',
+        createdAt: 0,
+      );
+
+      when(mockAuthService.refreshToken(any)).thenAnswer((_) async => response);
+
+      final result = await repository.refreshToken(
+        refreshToken: 'refreshToken',
+      );
+
+      expect(result, AuthModel.fromResponse(response));
+    });
+
+    test('When calling refreshToken failed, it returns NetworkExceptions error',
+        () async {
+      when(mockAuthService.refreshToken(any)).thenThrow(MockDioError());
+
+      result() => repository.refreshToken(refreshToken: 'refreshToken');
+
+      expect(result, throwsA(isA<NetworkExceptions>()));
+    });
+
+    test(
+        'When calling signOut successfully, it emits the corresponding response',
+        () async {
+      when(mockAuthService.signOut(any))
+          .thenAnswer((_) async => Future(() => null));
+
+      final result = await repository.signOut(
+        token: 'token',
+      );
+
+      expect(() async => result, isA<void>());
+    });
+
+    test('When calling signOut failed, it returns NetworkExceptions error',
+        () async {
+      when(mockAuthService.signOut(any)).thenThrow(MockDioError());
+
+      result() => repository.signOut(token: 'token');
 
       expect(result, throwsA(isA<NetworkExceptions>()));
     });

--- a/test/api/repository/survey_repository_test.dart
+++ b/test/api/repository/survey_repository_test.dart
@@ -111,8 +111,7 @@ void main() {
       expect(() async => result, isA<void>());
     });
 
-    test(
-        'When calling GetSurveyDetails failed, it returns NetworkExceptions error',
+    test('When calling SubmitSurvey failed, it returns NetworkExceptions error',
         () async {
       when(mockSurveyService.submitSurvey(any)).thenThrow(MockDioError());
 

--- a/test/mocks/generate_mocks.dart
+++ b/test/mocks/generate_mocks.dart
@@ -12,6 +12,7 @@ import 'package:survey_flutter_ic/usecase/get_profile_use_case.dart';
 import 'package:survey_flutter_ic/usecase/get_survey_details_use_case.dart';
 import 'package:survey_flutter_ic/usecase/get_survey_use_case.dart';
 import 'package:survey_flutter_ic/usecase/sign_in_use_case.dart';
+import 'package:survey_flutter_ic/usecase/sign_out_use_case.dart';
 import 'package:survey_flutter_ic/usecase/submit_survey_use_case.dart';
 
 @GenerateMocks([
@@ -28,6 +29,7 @@ import 'package:survey_flutter_ic/usecase/submit_survey_use_case.dart';
   GetProfileUseCase,
   GetSurveyDetailsUseCase,
   SubmitSurveyUseCase,
+  SignOutUseCase,
   DioError,
 ])
 main() {

--- a/test/usecase/sign_out_use_case_test.dart
+++ b/test/usecase/sign_out_use_case_test.dart
@@ -1,0 +1,49 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mockito/mockito.dart';
+import 'package:survey_flutter_ic/api/exception/network_exceptions.dart';
+import 'package:survey_flutter_ic/usecase/base/base_use_case.dart';
+import 'package:survey_flutter_ic/usecase/sign_out_use_case.dart';
+
+import '../mocks/generate_mocks.mocks.dart';
+
+void main() {
+  group('SignOutUseCase', () {
+    late MockAuthRepository mockRepository;
+    late MockAuthPersistence mockPersistence;
+    late SignOutUseCase useCase;
+
+    setUp(() {
+      mockRepository = MockAuthRepository();
+      mockPersistence = MockAuthPersistence();
+      useCase = SignOutUseCase(mockRepository, mockPersistence);
+    });
+
+    test('When calling signOut successfully, it returns the result Success',
+        () async {
+      when(mockRepository.signOut(
+        token: 'accessToken',
+      )).thenAnswer((_) async => Future(() => null));
+
+      when(mockPersistence.accessToken).thenAnswer((_) async => 'accessToken');
+
+      final result = await useCase.call();
+
+      expect(result, isA<Success>());
+    });
+
+    test('When calling signOut failed, it returns the result Failed', () async {
+      const exception = NetworkExceptions.unexpectedError();
+
+      when(mockRepository.signOut(
+        token: 'accessToken',
+      )).thenAnswer((_) => Future.error(exception));
+
+      when(mockPersistence.accessToken).thenAnswer((_) async => 'accessToken');
+
+      final result = await useCase.call();
+
+      expect(result, isA<Failed>());
+      expect((result as Failed).exception.actualException, exception);
+    });
+  });
+}


### PR DESCRIPTION
Close https://github.com/hoangnguyen92dn/survey-flutter-ic/issues/11

## What happened 👀

Call `POST /api/v1/oauth/revoke` to sign out with the following body:

```
{
  "token": "{{user_access_token}}",
  "client_id": "{{client_id}}",
  "client_secret": "{{client_secret}}"
}
```

## Insight 📝

- Add API request to handle sign out
- Add UnitTest

## Proof Of Work 📹

```
I/flutter (22892): *** Request ***
I/flutter (22892): uri: https://survey-api.nimblehq.co/api/v1/oauth/revoke
I/flutter (22892): method: POST
I/flutter (22892): responseType: ResponseType.json
I/flutter (22892): followRedirects: true
I/flutter (22892): persistentConnection: true
I/flutter (22892): connectTimeout: 0:00:03.000000
I/flutter (22892): sendTimeout: null
I/flutter (22892): receiveTimeout: 0:00:05.000000
I/flutter (22892): receiveDataWhenStatusError: true
I/flutter (22892): extra: {}
I/flutter (22892): headers:
I/flutter (22892):  Content-Type: application/json; charset=utf-8
I/flutter (22892):  Authorization: Bearer h9BXhSKIGnZGx1OHtFQL14QTifEE77Ey2r49wIX-TGA
I/flutter (22892): data:
I/flutter (22892): {token: h9BXhSKIGnZGx1OHtFQL14QTifEE77Ey2r49wIX-TGA, client_id: 6GbE8dhoz519l2N_F99StqoOs6Tcmm1rXgda4q__rIw, client_secret: _ayfIm7BeUAhx2W1OUqi20fwO3uNxfo1QstyKlFCgHw}
I/flutter (22892): 
I/flutter (22892): *** Response ***
I/flutter (22892): uri: https://survey-api.nimblehq.co/api/v1/oauth/revoke
I/flutter (22892): statusCode: 200
I/flutter (22892): headers:
I/flutter (22892):  connection: keep-alive
I/flutter (22892):  cache-control: max-age=0, private, must-revalidate
I/flutter (22892):  date: Wed, 26 Apr 2023 04:22:15 GMT
I/flutter (22892):  vary: Accept-Encoding, Origin
I/flutter (22892):  content-encoding: gzip
I/flutter (22892):  referrer-policy: strict-origin-when-cross-origin
I/flutter (22892):  report-to: {"endpoints":[{"url":"https:\/\/a.nel.cloudflare.com\/report\/v3?s=xeVTSEqZ3t3KGXSB%2FerXApjwIUELb9rHdFW5eauUXtWVKIPynhUhn0RppDRihg0x9IUnU9PgmFKcLIkWMMr8QzO3dUs5HWDb%2BC7u9tJHN32anHjxAgmz%2BoaqjgUJwLCfPZ7%2Bh7S6X8RL"}],"group":"cf-nel","max_age":604800}
I/flutter (22892):  cf-cache-status: DYNAMIC
I/flutter (22892):  x-permitted-cross-domain-policies: none
I/flutter (22892):  content-type: application/json; charset=utf-8
I/flutter (22892):  x-xss-protection: 0
I/flutter (22892):  server: cloudflare
I/flutter (22892):  x-request-id: e8015dab-5559-4474-ab73-c1711f78d085
I/flutter (22892):  alt-svc: h3=":443"; ma=86400, h3-29=":443"; ma=86400
I/flutter (22892):  content-length: 28
I/flutter (22892):  nel: {"success_fraction":0,"report_to":"cf-nel","max_age":604800}
I/flutter (22892):  x-download-options: noopen
I/flutter (22892):  cf-ray: 7bdc0b2499e80445-HKG
I/flutter (22892):  x-runtime: 0.010318
I/flutter (22892):  etag: W/"b9ec4c2a7a080b1916331a8d944a2402"
I/flutter (22892):  via: 1.1 vegur
I/flutter (22892):  x-frame-options: SAMEORIGIN
I/flutter (22892):  x-content-type-options: nosniff
I/flutter (22892): Response Text:
I/flutter (22892): {}
I/flutter (22892): 
```
