### PR TITLE
[#34][Integrate] As a user, I can quit the survey

### DIFF
--- a/assets/colors/colors.xml
+++ b/assets/colors/colors.xml
@@ -2,4 +2,6 @@
 <resource>
     <color name="gray">#FF15151A</color>
     <color name="black20">#33000000</color>
+    <color name="eerie_black">#FF1E1E1E</color>
+    <color name="blue">#FF007AFF</color>
 </resource>

--- a/integration_test/survey_questions_screen_test.dart
+++ b/integration_test/survey_questions_screen_test.dart
@@ -27,6 +27,7 @@ void surveyQuestionsScreenTest() {
     late Finder answerTextArea;
     late Finder answerForm;
     late Finder answerMultipleChoices;
+    late Finder quitSurveyConfirmationDialog;
 
     setUpAll(() async {
       await TestUtil.setupTestEnvironment();
@@ -50,6 +51,8 @@ void surveyQuestionsScreenTest() {
       answerForm = find.byKey(SurveyQuestionsWidgetId.answersForm);
       answerMultipleChoices =
           find.byKey(SurveyQuestionsWidgetId.answersMultipleChoices);
+      quitSurveyConfirmationDialog =
+          find.byKey(SurveyQuestionsWidgetId.quitSurveyConfirmationDialog);
     });
 
     Future nextQuestionTest(
@@ -92,6 +95,7 @@ void surveyQuestionsScreenTest() {
       expect(answerTextArea, findsNothing);
       expect(answerForm, findsNothing);
       expect(answerMultipleChoices, findsNothing);
+      expect(quitSurveyConfirmationDialog, findsNothing);
     });
 
     testWidgets(
@@ -242,6 +246,20 @@ void surveyQuestionsScreenTest() {
       await answerTest(answerMultipleChoices, findsNothing);
       await answerTest(nextQuestionButton, findsNothing);
       await answerTest(submitButton, findsOneWidget);
+    });
+
+    testWidgets(
+        "When click on the close button, it displays the confirmation dialog correctly",
+        (WidgetTester tester) async {
+      await FakeData.initDefault();
+      await tester
+          .pumpWidget(TestUtil.pumpWidgetWithRoutePath('/home/questions/1'));
+      await tester.pumpAndSettle();
+
+      await tester.tap(closeSurveyButton);
+      await tester.pumpAndSettle();
+
+      expect(quitSurveyConfirmationDialog, findsOneWidget);
     });
   });
 }

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -10,6 +10,11 @@
   "survey_details_start_survey_button": "Start survey",
   "survey_details_submit_survey_button": "Submit",
 
+  "survey_question_quit_confirmation_title": "Warning!",
+  "survey_question_quit_confirmation_description": "Are you sure you want to quit the survey?",
+  "survey_question_quit_confirmation_yes": "Yes",
+  "survey_question_quit_confirmation_cancel": "Cancel",
+
   "survey_question_nps_lowest_description": "Not at all Likely",
   "survey_question_nps_highest_description": "Extremely Likely",
 

--- a/lib/theme/colors.dart
+++ b/lib/theme/colors.dart
@@ -2,3 +2,5 @@ import 'package:survey_flutter_ic/gen/colors.gen.dart';
 
 const textColorGray = ColorName.gray;
 const textColorGrayDisabled = ColorName.black20;
+const dialogBackground = ColorName.eerieBlack;
+const dialogButtonColor = ColorName.blue;

--- a/lib/ui/questions/survey_questions_screen.dart
+++ b/lib/ui/questions/survey_questions_screen.dart
@@ -208,6 +208,7 @@ class _SurveyQuestionsScreenScreenState
     showDialog(
       context: context,
       builder: (_) => ConfirmationDialog(
+        key: SurveyQuestionsWidgetId.quitSurveyConfirmationDialog,
         title: context.localization.survey_question_quit_confirmation_title,
         description:
             context.localization.survey_question_quit_confirmation_description,

--- a/lib/ui/questions/survey_questions_screen.dart
+++ b/lib/ui/questions/survey_questions_screen.dart
@@ -12,6 +12,7 @@ import 'package:survey_flutter_ic/ui/questions/survey_question_ui_model.dart';
 import 'package:survey_flutter_ic/ui/questions/survey_question_view.dart';
 import 'package:survey_flutter_ic/ui/questions/survey_questions_view_model.dart';
 import 'package:survey_flutter_ic/ui/questions/survey_questions_widget_id.dart';
+import 'package:survey_flutter_ic/widget/confirmation_dialog.dart';
 import 'package:survey_flutter_ic/widget/flat_button_text.dart';
 import 'package:survey_flutter_ic/widget/white_right_arrow_button.dart';
 
@@ -120,7 +121,7 @@ class _SurveyQuestionsScreenScreenState
             IconButton(
               key: SurveyQuestionsWidgetId.closeSurveyButton,
               icon: SvgPicture.asset(Assets.images.icClose.path),
-              onPressed: () => context.pop(), // TODO Add confirmation dialog
+              onPressed: () => _showConfirmationDialog(context),
             )
           ],
         ),
@@ -199,6 +200,24 @@ class _SurveyQuestionsScreenScreenState
             margin: const EdgeInsets.symmetric(vertical: 50, horizontal: 50),
             child: const CircularProgressIndicator(
                 valueColor: AlwaysStoppedAnimation<Color>(Colors.white))),
+      ),
+    );
+  }
+
+  _showConfirmationDialog(BuildContext context) {
+    showDialog(
+      context: context,
+      builder: (_) => ConfirmationDialog(
+        title: context.localization.survey_question_quit_confirmation_title,
+        description:
+            context.localization.survey_question_quit_confirmation_description,
+        positiveActionText:
+            context.localization.survey_question_quit_confirmation_yes,
+        negativeActionText:
+            context.localization.survey_question_quit_confirmation_cancel,
+        onConfirmed: () {
+          context.pop();
+        },
       ),
     );
   }

--- a/lib/ui/questions/survey_questions_widget_id.dart
+++ b/lib/ui/questions/survey_questions_widget_id.dart
@@ -17,4 +17,6 @@ class SurveyQuestionsWidgetId {
   static const answersTextArea = Key('answersTextArea');
   static const answersForm = Key('answersForm');
   static const answersMultipleChoices = Key('answersMultipleChoices');
+  static const quitSurveyConfirmationDialog =
+      Key('quitSurveyConfirmationDialog');
 }

--- a/lib/widget/confirmation_dialog.dart
+++ b/lib/widget/confirmation_dialog.dart
@@ -1,10 +1,9 @@
 import 'package:flutter/material.dart';
-import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 import 'package:survey_flutter_ic/theme/colors.dart';
 import 'package:survey_flutter_ic/theme/dimens.dart';
 
-class ConfirmationDialog extends ConsumerStatefulWidget {
+class ConfirmationDialog extends StatelessWidget {
   final String title;
   final String description;
   final String positiveActionText;
@@ -21,16 +20,11 @@ class ConfirmationDialog extends ConsumerStatefulWidget {
   });
 
   @override
-  ConsumerState<ConfirmationDialog> createState() => _ConfirmationDialogState();
-}
-
-class _ConfirmationDialogState extends ConsumerState<ConfirmationDialog> {
-  @override
   Widget build(BuildContext context) {
     return AlertDialog(
       backgroundColor: dialogBackground.withOpacity(0.9),
       title: Text(
-        widget.title,
+        title,
         style: const TextStyle(
           color: Colors.white,
           fontSize: fontSize17,
@@ -38,7 +32,7 @@ class _ConfirmationDialogState extends ConsumerState<ConfirmationDialog> {
         ),
       ),
       content: Text(
-        widget.description,
+        description,
         style: const TextStyle(
           color: Colors.white,
           fontSize: fontSize17,
@@ -49,10 +43,10 @@ class _ConfirmationDialogState extends ConsumerState<ConfirmationDialog> {
         TextButton(
           onPressed: () {
             context.pop(true);
-            widget.onConfirmed.call();
+            onConfirmed.call();
           },
           child: Text(
-            widget.positiveActionText,
+            positiveActionText,
             style: const TextStyle(
               color: dialogButtonColor,
               fontSize: fontSize17,
@@ -63,7 +57,7 @@ class _ConfirmationDialogState extends ConsumerState<ConfirmationDialog> {
         TextButton(
           onPressed: () => context.pop(false),
           child: Text(
-            widget.negativeActionText,
+            negativeActionText,
             style: const TextStyle(
               color: dialogButtonColor,
               fontSize: fontSize17,

--- a/lib/widget/confirmation_dialog.dart
+++ b/lib/widget/confirmation_dialog.dart
@@ -1,0 +1,77 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+import 'package:survey_flutter_ic/theme/colors.dart';
+import 'package:survey_flutter_ic/theme/dimens.dart';
+
+class ConfirmationDialog extends ConsumerStatefulWidget {
+  final String title;
+  final String description;
+  final String positiveActionText;
+  final String negativeActionText;
+  final VoidCallback onConfirmed;
+
+  const ConfirmationDialog({
+    super.key,
+    required this.title,
+    required this.description,
+    required this.positiveActionText,
+    required this.negativeActionText,
+    required this.onConfirmed,
+  });
+
+  @override
+  ConsumerState<ConfirmationDialog> createState() => _ConfirmationDialogState();
+}
+
+class _ConfirmationDialogState extends ConsumerState<ConfirmationDialog> {
+  @override
+  Widget build(BuildContext context) {
+    return AlertDialog(
+      backgroundColor: dialogBackground.withOpacity(0.9),
+      title: Text(
+        widget.title,
+        style: const TextStyle(
+          color: Colors.white,
+          fontSize: fontSize17,
+          fontWeight: FontWeight.bold,
+        ),
+      ),
+      content: Text(
+        widget.description,
+        style: const TextStyle(
+          color: Colors.white,
+          fontSize: fontSize17,
+          fontWeight: FontWeight.normal,
+        ),
+      ),
+      actions: <Widget>[
+        TextButton(
+          onPressed: () {
+            context.pop(true);
+            widget.onConfirmed.call();
+          },
+          child: Text(
+            widget.positiveActionText,
+            style: const TextStyle(
+              color: dialogButtonColor,
+              fontSize: fontSize17,
+              fontWeight: FontWeight.normal,
+            ),
+          ),
+        ),
+        TextButton(
+          onPressed: () => context.pop(false),
+          child: Text(
+            widget.negativeActionText,
+            style: const TextStyle(
+              color: dialogButtonColor,
+              fontSize: fontSize17,
+              fontWeight: FontWeight.bold,
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+}


### PR DESCRIPTION
Close https://github.com/hoangnguyen92dn/survey-flutter-ic/issues/34

## What happened 👀

When a user decides to cancel/dismiss an ongoing survey, he/she must be asked to confirm before dismissing it. This is to prevent any unintentional dismissal of ongoing survey. Otherwise, if a user loses the progress of his/her survey, there are high chances that it might upset the user and unhappy users will unlikely re-take the survey.

It is important to note that if there is no progress on the survey, the mobile app should dismiss the screen without any prompt since the user might just want to see a preview of the questions or start the survey by mistake.

## Insight 📝

- Create a new confirmation dialog
- Show dialog on close survey clicked
- Add UnitTest

## Proof Of Work 📹

https://user-images.githubusercontent.com/6950766/234755383-4721f1e5-96a3-4e69-81ba-1ca5f97739b5.mp4

![image](https://user-images.githubusercontent.com/6950766/234755300-3d761fc1-d81d-4a49-b021-6eef88885001.png)

