### PR TITLE
[#37] [Integrate] As a user, I can see pull to refresh the survey list

### DIFF
--- a/integration_test/fake_data/fake_persistence/fake_survey_persistence.dart
+++ b/integration_test/fake_data/fake_persistence/fake_survey_persistence.dart
@@ -1,0 +1,20 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:survey_flutter_ic/database/dto/survey_dto.dart';
+import 'package:survey_flutter_ic/database/persistence/survey_persistence.dart';
+
+class FakeSurveyPersistence extends Fake implements SurveyPersistence {
+  @override
+  Future<List<SurveyDto>> getSurveys() async {
+    return List.empty();
+  }
+
+  @override
+  Future<void> add(List<SurveyDto> surveys) async {
+    return Future.value();
+  }
+
+  @override
+  Future<void> clear() async {
+    return Future.value();
+  }
+}

--- a/integration_test/utils/test_util.dart
+++ b/integration_test/utils/test_util.dart
@@ -6,10 +6,12 @@ import 'package:package_info_plus/package_info_plus.dart';
 import 'package:survey_flutter_ic/api/repository/auth_repository.dart';
 import 'package:survey_flutter_ic/api/repository/survey_repository.dart';
 import 'package:survey_flutter_ic/api/repository/user_repository.dart';
+import 'package:survey_flutter_ic/database/hive_persistence.dart';
 import 'package:survey_flutter_ic/di/provider/di.dart';
 import 'package:survey_flutter_ic/main.dart';
 import 'package:survey_flutter_ic/navigation/app_router.dart';
 
+import '../fake_data/fake_persistence/fake_survey_persistence.dart';
 import '../fake_data/fake_services/fake_auth_service.dart';
 import '../fake_data/fake_services/fake_survey_service.dart';
 import '../fake_data/fake_services/fake_user_service.dart';
@@ -64,7 +66,9 @@ class TestUtil {
 
   static Future setupTestEnvironment() async {
     _initDependencies();
-    configureInjection();
+    await initHivePersistence();
+
+    await configureInjection();
     getIt.allowReassignment = true;
 
     // FIXME: Can not mock the Service layer
@@ -76,7 +80,9 @@ class TestUtil {
         AuthRepositoryImpl(FakeAuthService()));
     getIt.registerSingleton<UserRepository>(
         UserRepositoryImpl(FakeUserService()));
-    getIt.registerSingleton<SurveyRepository>(
-        SurveyRepositoryImpl(FakeSurveyService()));
+    getIt.registerSingleton<SurveyRepository>(SurveyRepositoryImpl(
+      FakeSurveyService(),
+      FakeSurveyPersistence(),
+    ));
   }
 }

--- a/lib/api/repository/survey_repository.dart
+++ b/lib/api/repository/survey_repository.dart
@@ -2,12 +2,14 @@ import 'package:injectable/injectable.dart';
 import 'package:survey_flutter_ic/api/exception/network_exceptions.dart';
 import 'package:survey_flutter_ic/api/request/submit_survey_request.dart';
 import 'package:survey_flutter_ic/api/service/survey_service.dart';
+import 'package:survey_flutter_ic/database/dto/survey_dto.dart';
+import 'package:survey_flutter_ic/database/persistence/survey_persistence.dart';
 import 'package:survey_flutter_ic/model/survey_details_model.dart';
 import 'package:survey_flutter_ic/model/survey_model.dart';
 
 abstract class SurveyRepository {
   Future<List<SurveyModel>> getSurveys({
-    required int number,
+    required int pageNumber,
     required int size,
   });
 
@@ -23,24 +25,41 @@ abstract class SurveyRepository {
 @Singleton(as: SurveyRepository)
 class SurveyRepositoryImpl extends SurveyRepository {
   final SurveyService _surveyService;
+  final SurveyPersistence _surveyPersistence;
 
-  SurveyRepositoryImpl(this._surveyService);
+  SurveyRepositoryImpl(
+    this._surveyService,
+    this._surveyPersistence,
+  );
 
   @override
   Future<List<SurveyModel>> getSurveys({
-    required int number,
+    required int pageNumber,
     required int size,
   }) async {
     try {
-      final response = await _surveyService.getSurveys(number, size);
+      final response = await _surveyService.getSurveys(pageNumber, size);
       final surveysModel = response.surveys
           .map((survey) => SurveyModel.fromResponse(survey))
           .toList();
+
+      await _cacheSurveysToPersistence(pageNumber, surveysModel);
 
       return surveysModel;
     } catch (exception) {
       throw NetworkExceptions.fromDioException(exception);
     }
+  }
+
+  Future<void> _cacheSurveysToPersistence(
+    int pageNumber,
+    List<SurveyModel> surveysModel,
+  ) async {
+    if (pageNumber == 1) {
+      await _surveyPersistence.clear();
+    }
+    await _surveyPersistence
+        .add(surveysModel.map((e) => SurveyDto.fromModel(e)).toList());
   }
 
   @override

--- a/lib/database/dto/survey_dto.dart
+++ b/lib/database/dto/survey_dto.dart
@@ -1,0 +1,61 @@
+import 'package:hive/hive.dart';
+import 'package:survey_flutter_ic/model/survey_model.dart';
+
+part 'survey_dto.g.dart';
+
+@HiveType(typeId: 0)
+class SurveyDto extends HiveObject {
+  @HiveField(0)
+  final String id;
+  @HiveField(1)
+  final String title;
+  @HiveField(2)
+  final String description;
+  @HiveField(3)
+  final bool isActive;
+  @HiveField(4)
+  final String coverImageUrl;
+  @HiveField(5)
+  final String largeCoverImageUrl;
+  @HiveField(6)
+  final String createdAt;
+  @HiveField(7)
+  final String surveyType;
+
+  SurveyDto({
+    required this.id,
+    required this.title,
+    required this.description,
+    required this.isActive,
+    required this.coverImageUrl,
+    required this.largeCoverImageUrl,
+    required this.createdAt,
+    required this.surveyType,
+  });
+
+  factory SurveyDto.fromModel(SurveyModel model) {
+    return SurveyDto(
+      id: model.id,
+      title: model.title,
+      description: model.description,
+      isActive: model.isActive,
+      coverImageUrl: model.coverImageUrl,
+      largeCoverImageUrl: model.coverImageUrl,
+      createdAt: model.createdAt,
+      surveyType: model.surveyType,
+    );
+  }
+
+  SurveyModel toModel() {
+    return SurveyModel(
+      id: id,
+      title: title,
+      description: description,
+      isActive: isActive,
+      coverImageUrl: coverImageUrl,
+      largeCoverImageUrl: largeCoverImageUrl,
+      createdAt: createdAt,
+      surveyType: surveyType,
+    );
+  }
+}

--- a/lib/database/hive_persistence.dart
+++ b/lib/database/hive_persistence.dart
@@ -1,0 +1,9 @@
+import 'package:hive_flutter/hive_flutter.dart';
+import 'package:survey_flutter_ic/database/dto/survey_dto.dart';
+
+const String surveyBoxName = 'surveyBox';
+
+Future<void> initHivePersistence() async {
+  await Hive.initFlutter();
+  Hive.registerAdapter(SurveyDtoAdapter());
+}

--- a/lib/database/persistence/survey_persistence.dart
+++ b/lib/database/persistence/survey_persistence.dart
@@ -1,0 +1,49 @@
+import 'package:hive_flutter/hive_flutter.dart';
+import 'package:injectable/injectable.dart';
+import 'package:survey_flutter_ic/database/dto/survey_dto.dart';
+import 'package:survey_flutter_ic/database/hive_persistence.dart';
+
+abstract class SurveyPersistence {
+  Future<List<SurveyDto>> getSurveys();
+
+  Future<void> add(List<SurveyDto> surveys);
+
+  Future<void> clear();
+}
+
+@Singleton(as: SurveyPersistence)
+class SurveyPersistenceImpl extends SurveyPersistence {
+  final Box _surveyBox;
+  final String _surveyKey = 'surveyKey';
+
+  SurveyPersistenceImpl(
+    @Named(surveyBoxName) this._surveyBox,
+  );
+
+  @override
+  Future<List<SurveyDto>> getSurveys() {
+    return Future.value(
+      List<SurveyDto>.from(
+        _surveyBox.get(
+          _surveyKey,
+          defaultValue: [],
+        ),
+      ),
+    );
+  }
+
+  @override
+  Future<void> add(List<SurveyDto> surveys) async {
+    final currentSurveys = _surveyBox.get(
+      _surveyKey,
+      defaultValue: <SurveyDto>[],
+    ) as List<SurveyDto>;
+    currentSurveys.addAll(surveys);
+    await _surveyBox.put(_surveyKey, currentSurveys);
+  }
+
+  @override
+  Future<void> clear() async {
+    await _surveyBox.delete(_surveyKey);
+  }
+}

--- a/lib/di/module/database_module.dart
+++ b/lib/di/module/database_module.dart
@@ -1,0 +1,12 @@
+import 'package:hive_flutter/hive_flutter.dart';
+import 'package:injectable/injectable.dart';
+import 'package:survey_flutter_ic/database/hive_persistence.dart';
+
+@module
+abstract class DatabaseModule {
+
+  @Named(surveyBoxName)
+  @singleton
+  @preResolve
+  Future<Box> get surveyBox => Hive.openBox(surveyBoxName);
+}

--- a/lib/di/module/database_module.dart
+++ b/lib/di/module/database_module.dart
@@ -4,7 +4,6 @@ import 'package:survey_flutter_ic/database/hive_persistence.dart';
 
 @module
 abstract class DatabaseModule {
-
   @Named(surveyBoxName)
   @singleton
   @preResolve

--- a/lib/di/provider/di.dart
+++ b/lib/di/provider/di.dart
@@ -10,4 +10,4 @@ final getIt = GetIt.instance;
   preferRelativeImports: true,
   asExtension: false,
 )
-void configureInjection() => $initGetIt(getIt);
+Future<void> configureInjection() => $initGetIt(getIt);

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -5,6 +5,7 @@ import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 import 'package:stack_trace/stack_trace.dart' as stack_trace;
+import 'package:survey_flutter_ic/database/hive_persistence.dart';
 import 'package:survey_flutter_ic/di/provider/di.dart';
 import 'package:survey_flutter_ic/navigation/app_router.dart';
 import 'package:survey_flutter_ic/theme/app_color_scheme.dart';
@@ -18,7 +19,8 @@ void main() async {
     if (stack is stack_trace.Chain) return stack.toTrace().vmTrace;
     return stack;
   };
-  configureInjection();
+  await initHivePersistence();
+  await configureInjection();
   runApp(const ProviderScope(child: MyApp()));
 }
 

--- a/lib/ui/home/home_screen.dart
+++ b/lib/ui/home/home_screen.dart
@@ -46,17 +46,33 @@ class _HomeScreenState extends ConsumerState<HomeScreen> {
 
     final state = ref.watch(homeViewModelProvider);
 
+    return state.maybeWhen(
+      init: () => const SurveyShimmerLoading(),
+      loading: () => const SurveyShimmerLoading(),
+      success: () => _buildHome(),
+      loadCachedSurveysSuccess: () => _buildHome(),
+      error: (message) => showToastMessage(message),
+      orElse: () => const SizedBox.shrink(),
+    );
+  }
+
+  Widget _buildHome() => Consumer(builder: (context, ref, child) {
     return Scaffold(
       key: _scaffoldKey,
       endDrawer: _buildHomeDrawer(),
-      body: state.maybeWhen(
-        init: () => const SurveyShimmerLoading(),
-        success: () => _buildHomeContent(),
-        error: (message) => showToastMessage(message),
-        orElse: () => const SizedBox.shrink(),
+      body: RefreshIndicator(
+        color: Colors.white,
+        backgroundColor: Colors.white30,
+        onRefresh: () =>  ref
+            .read(homeViewModelProvider.notifier)
+            .getSurveys(),
+        child: SingleChildScrollView(
+          physics: const AlwaysScrollableScrollPhysics(),
+          child: _buildHomeContent(),
+        ),
       ),
     );
-  }
+  });
 
   Widget _buildHomeContent() => Consumer(
         builder: (context, ref, child) {

--- a/lib/ui/home/home_view_model.dart
+++ b/lib/ui/home/home_view_model.dart
@@ -67,7 +67,7 @@ class HomeViewModel extends StateNotifier<HomeViewState> {
     this._signOutUseCase,
     this._getCachedSurveysUseCase,
   ) : super(const HomeViewState.init()) {
-    _getCachedSurveys();
+    getSurveys(isPreload: true);
   }
 
   void setVisibleSurveyIndex(int index) {
@@ -99,27 +99,17 @@ class HomeViewModel extends StateNotifier<HomeViewState> {
     _todayStreamController.add(DateTime.now().getFormattedString());
   }
 
-  Future getSurveys() async {
-    final input = GetSurveysInput(
-      pageNumber: _defaultFirstPageIndex,
-      pageSize: _defaultPageSize,
-    );
-
-    final result = await _getSurveyUseCase.call(input);
-
-    if (result is Failed<List<SurveyModel>>) {
-      final error = result.getErrorMessage();
-      state = HomeViewState.error(error);
+  Future getSurveys({bool isPreload = false}) async {
+    late Result<List<SurveyModel>> result;
+    if (isPreload) {
+      result = await _getCachedSurveysUseCase.call();
     } else {
-      final surveys = (result as Success<List<SurveyModel>>).value;
-      final surveyUiModels =
-          surveys.map((survey) => SurveyUiModel.fromModel(survey));
-      _surveysStreamController.add(surveyUiModels.toList(growable: false));
+      final input = GetSurveysInput(
+        pageNumber: _defaultFirstPageIndex,
+        pageSize: _defaultPageSize,
+      );
+      result = await _getSurveyUseCase.call(input);
     }
-  }
-
-  Future _getCachedSurveys() async {
-    final result = await _getCachedSurveysUseCase.call();
 
     if (result is Failed<List<SurveyModel>>) {
       final error = result.getErrorMessage();

--- a/lib/ui/home/home_view_model.dart
+++ b/lib/ui/home/home_view_model.dart
@@ -130,8 +130,6 @@ class HomeViewModel extends StateNotifier<HomeViewState> {
           surveys.map((survey) => SurveyUiModel.fromModel(survey));
       _surveysStreamController.add(surveyUiModels.toList(growable: false));
     }
-
-    state = const HomeViewState.loadCachedSurveysSuccess();
   }
 
   Future signOut() async {

--- a/lib/ui/home/home_view_state.dart
+++ b/lib/ui/home/home_view_state.dart
@@ -8,6 +8,8 @@ class HomeViewState with _$HomeViewState {
 
   const factory HomeViewState.loading() = _Loading;
 
+  const factory HomeViewState.loadCachedSurveysSuccess() = _LoadCachedSurveysSuccess;
+
   const factory HomeViewState.success() = _Success;
 
   const factory HomeViewState.error(String message) = _Error;

--- a/lib/ui/home/home_view_state.dart
+++ b/lib/ui/home/home_view_state.dart
@@ -8,8 +8,6 @@ class HomeViewState with _$HomeViewState {
 
   const factory HomeViewState.loading() = _Loading;
 
-  const factory HomeViewState.loadCachedSurveysSuccess() = _LoadCachedSurveysSuccess;
-
   const factory HomeViewState.success() = _Success;
 
   const factory HomeViewState.error(String message) = _Error;

--- a/lib/ui/surveys/survey_view.dart
+++ b/lib/ui/surveys/survey_view.dart
@@ -30,15 +30,15 @@ class _SurveyViewState extends ConsumerState<SurveyView> {
     return SizedBox(
       height: MediaQuery.of(context).size.height,
       child: PageView.builder(
-          controller: _pageController,
-          onPageChanged: (index) {
-            widget.onPageChanged.call(index);
-          },
-          itemCount: widget.surveys.length,
-          itemBuilder: (_, index) {
-            return _buildPageItem(widget.surveys[index]);
-          },
-        ),
+        controller: _pageController,
+        onPageChanged: (index) {
+          widget.onPageChanged.call(index);
+        },
+        itemCount: widget.surveys.length,
+        itemBuilder: (_, index) {
+          return _buildPageItem(widget.surveys[index]);
+        },
+      ),
     );
   }
 

--- a/lib/ui/surveys/survey_view.dart
+++ b/lib/ui/surveys/survey_view.dart
@@ -27,9 +27,9 @@ class _SurveyViewState extends ConsumerState<SurveyView> {
 
   @override
   Widget build(BuildContext context) {
-    return Stack(
-      children: [
-        PageView.builder(
+    return SizedBox(
+      height: MediaQuery.of(context).size.height,
+      child: PageView.builder(
           controller: _pageController,
           onPageChanged: (index) {
             widget.onPageChanged.call(index);
@@ -39,7 +39,6 @@ class _SurveyViewState extends ConsumerState<SurveyView> {
             return _buildPageItem(widget.surveys[index]);
           },
         ),
-      ],
     );
   }
 

--- a/lib/usecase/get_cached_survey_use_case.dart
+++ b/lib/usecase/get_cached_survey_use_case.dart
@@ -1,0 +1,25 @@
+import 'dart:async';
+
+import 'package:injectable/injectable.dart';
+import 'package:survey_flutter_ic/api/exception/network_exceptions.dart';
+import 'package:survey_flutter_ic/database/persistence/survey_persistence.dart';
+import 'package:survey_flutter_ic/model/survey_model.dart';
+import 'package:survey_flutter_ic/usecase/base/base_use_case.dart';
+
+@Injectable()
+class GetCachedSurveysUseCase extends NoParamsUseCase<List<SurveyModel>> {
+  final SurveyPersistence _persistence;
+
+  const GetCachedSurveysUseCase(this._persistence);
+
+  @override
+  Future<Result<List<SurveyModel>>> call() {
+    return _persistence
+        .getSurveys()
+        .then((value) => value.map((e) => e.toModel()).toList())
+        // ignore: unnecessary_cast
+        .then((value) => Success(value) as Result<List<SurveyModel>>)
+        .onError<NetworkExceptions>(
+            (exception, stackTrace) => Failed(UseCaseException(exception)));
+  }
+}

--- a/lib/usecase/get_survey_use_case.dart
+++ b/lib/usecase/get_survey_use_case.dart
@@ -26,7 +26,7 @@ class GetSurveysUseCase extends UseCase<List<SurveyModel>, GetSurveysInput> {
   Future<Result<List<SurveyModel>>> call(GetSurveysInput params) {
     return _repository
         .getSurveys(
-          number: params.pageNumber,
+          pageNumber: params.pageNumber,
           size: params.pageSize,
         )
         // ignore: unnecessary_cast

--- a/lib/usecase/sign_out_use_case.dart
+++ b/lib/usecase/sign_out_use_case.dart
@@ -3,6 +3,7 @@ import 'dart:async';
 import 'package:injectable/injectable.dart';
 import 'package:survey_flutter_ic/api/exception/network_exceptions.dart';
 import 'package:survey_flutter_ic/api/persistence/auth_persistence.dart';
+import 'package:survey_flutter_ic/database/persistence/survey_persistence.dart';
 import 'package:survey_flutter_ic/usecase/base/base_use_case.dart';
 
 import '../api/repository/auth_repository.dart';
@@ -10,24 +11,30 @@ import '../api/repository/auth_repository.dart';
 @Injectable()
 class SignOutUseCase extends NoParamsUseCase<void> {
   final AuthRepository _repository;
-  final AuthPersistence _persistence;
+  final AuthPersistence _authPersistence;
+  final SurveyPersistence _surveyPersistence;
 
-  const SignOutUseCase(this._repository, this._persistence);
+  const SignOutUseCase(
+    this._repository,
+    this._authPersistence,
+    this._surveyPersistence,
+  );
 
   @override
   Future<Result<void>> call() async {
-    final token = await _persistence.accessToken ?? '';
+    final token = await _authPersistence.accessToken ?? '';
     return _repository
         .signOut(token: token)
         // ignore: unnecessary_cast
-        .then((_) => clearTokens())
+        .then((_) => clearPersistence())
         .onError<NetworkExceptions>(
             (exception, stackTrace) => Failed(UseCaseException(exception)));
   }
 
-  Future<Result<void>> clearTokens() async {
+  Future<Result<void>> clearPersistence() async {
     try {
-      await _persistence.clearAllStorage();
+      await _surveyPersistence.clear();
+      await _authPersistence.clearAllStorage();
       return Success(null);
     } catch (exception) {
       return Failed(UseCaseException(exception));

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -495,6 +495,30 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.2.0"
+  hive:
+    dependency: "direct main"
+    description:
+      name: hive
+      sha256: "8dcf6db979d7933da8217edcec84e9df1bdb4e4edc7fc77dbd5aa74356d6d941"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.2.3"
+  hive_flutter:
+    dependency: "direct main"
+    description:
+      name: hive_flutter
+      sha256: dca1da446b1d808a51689fb5d0c6c9510c0a2ba01e22805d492c73b68e33eecc
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.1.0"
+  hive_generator:
+    dependency: "direct main"
+    description:
+      name: hive_generator
+      sha256: "65998cc4d2cd9680a3d9709d893d2f6bb15e6c1f92626c3f1fa650b4b3281521"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.0"
   hotreloader:
     dependency: transitive
     description:
@@ -708,6 +732,54 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.0.1"
+  path_provider:
+    dependency: transitive
+    description:
+      name: path_provider
+      sha256: c7edf82217d4b2952b2129a61d3ad60f1075b9299e629e149a8d2e39c2e6aad4
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.14"
+  path_provider_android:
+    dependency: transitive
+    description:
+      name: path_provider_android
+      sha256: da97262be945a72270513700a92b39dd2f4a54dad55d061687e2e37a6390366a
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.25"
+  path_provider_foundation:
+    dependency: transitive
+    description:
+      name: path_provider_foundation
+      sha256: ad4c4d011830462633f03eb34445a45345673dfd4faf1ab0b4735fbd93b19183
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.2.2"
+  path_provider_linux:
+    dependency: transitive
+    description:
+      name: path_provider_linux
+      sha256: "2ae08f2216225427e64ad224a24354221c2c7907e448e6e0e8b57b1eb9f10ad1"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.1.10"
+  path_provider_platform_interface:
+    dependency: transitive
+    description:
+      name: path_provider_platform_interface
+      sha256: "57585299a729335f1298b43245842678cb9f43a6310351b18fb577d6e33165ec"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.6"
+  path_provider_windows:
+    dependency: transitive
+    description:
+      name: path_provider_windows
+      sha256: f53720498d5a543f9607db4b0e997c4b5438884de25b0f73098cc2671a51b130
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.1.5"
   permission_handler:
     dependency: "direct main"
     description:
@@ -1161,6 +1233,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.1.3"
+  xdg_directories:
+    dependency: transitive
+    description:
+      name: xdg_directories
+      sha256: ee1505df1426458f7f60aac270645098d318a8b4766d85fde75f76f2e21807d1
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.0"
   xml:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -48,6 +48,9 @@ dependencies:
   stack_trace: ^1.11.0
   flutter_picker: ^2.1.0
   lottie: ^2.3.2
+  hive: ^2.2.3
+  hive_generator: ^2.0.0
+  hive_flutter: ^1.1.0
 
 dev_dependencies:
   build_runner: ^2.3.3

--- a/test/api/repository/survey_repository_test.dart
+++ b/test/api/repository/survey_repository_test.dart
@@ -42,7 +42,7 @@ void main() {
           .thenAnswer((_) async => expected);
 
       final result = await repository.getSurveys(
-        number: 1,
+        pageNumber: 1,
         size: 10,
       );
 
@@ -54,7 +54,7 @@ void main() {
         () async {
       when(mockSurveyService.getSurveys(any, any)).thenThrow(MockDioError());
 
-      result() => repository.getSurveys(number: 1, size: 10);
+      result() => repository.getSurveys(pageNumber: 1, size: 10);
 
       expect(result, throwsA(isA<NetworkExceptions>()));
     });

--- a/test/api/repository/survey_repository_test.dart
+++ b/test/api/repository/survey_repository_test.dart
@@ -24,11 +24,16 @@ void main() {
 
   group('SurveyRepository', () {
     late MockSurveyService mockSurveyService;
+    late MockSurveyPersistence mockSurveyPersistence;
     late SurveyRepository repository;
 
     setUp(() {
       mockSurveyService = MockSurveyService();
-      repository = SurveyRepositoryImpl(mockSurveyService);
+      mockSurveyPersistence = MockSurveyPersistence();
+      repository = SurveyRepositoryImpl(
+        mockSurveyService,
+        mockSurveyPersistence,
+      );
     });
 
     test(
@@ -48,6 +53,9 @@ void main() {
 
       expect(result.first, SurveyModel.fromResponse(expected.surveys.first));
       expect(result.last, SurveyModel.fromResponse(expected.surveys.last));
+
+      verify(mockSurveyPersistence.clear()).called(1);
+      verify(mockSurveyPersistence.add(any)).called(1);
     });
 
     test('When calling GetSurveys failed, it returns NetworkExceptions error',

--- a/test/mocks/generate_mocks.dart
+++ b/test/mocks/generate_mocks.dart
@@ -8,6 +8,8 @@ import 'package:survey_flutter_ic/api/repository/user_repository.dart';
 import 'package:survey_flutter_ic/api/service/auth_service.dart';
 import 'package:survey_flutter_ic/api/service/survey_service.dart';
 import 'package:survey_flutter_ic/api/service/user_service.dart';
+import 'package:survey_flutter_ic/database/persistence/survey_persistence.dart';
+import 'package:survey_flutter_ic/usecase/get_cached_survey_use_case.dart';
 import 'package:survey_flutter_ic/usecase/get_profile_use_case.dart';
 import 'package:survey_flutter_ic/usecase/get_survey_details_use_case.dart';
 import 'package:survey_flutter_ic/usecase/get_survey_use_case.dart';
@@ -30,6 +32,8 @@ import 'package:survey_flutter_ic/usecase/submit_survey_use_case.dart';
   GetSurveyDetailsUseCase,
   SubmitSurveyUseCase,
   SignOutUseCase,
+  SurveyPersistence,
+  GetCachedSurveysUseCase,
   DioError,
 ])
 main() {

--- a/test/ui/home/home_view_model_test.dart
+++ b/test/ui/home/home_view_model_test.dart
@@ -17,6 +17,7 @@ void main() {
     late MockGetProfileUseCase mockGetProfileUseCase;
     late MockGetSurveysUseCase mockGetSurveysUseCase;
     late MockSignOutUseCase mockSignOutUseCase;
+    late MockGetCachedSurveysUseCase mockGetCachedSurveysUseCase;
     late HomeViewModel viewModel;
     late ProviderContainer container;
 
@@ -24,20 +25,33 @@ void main() {
       mockGetProfileUseCase = MockGetProfileUseCase();
       mockGetSurveysUseCase = MockGetSurveysUseCase();
       mockSignOutUseCase = MockSignOutUseCase();
+      mockGetCachedSurveysUseCase = MockGetCachedSurveysUseCase();
+
+      const cachedSurveys = [
+        SurveyModel(
+          id: 'id',
+          title: 'title',
+          description: 'description',
+          isActive: true,
+          coverImageUrl: 'coverImageUrl',
+          largeCoverImageUrl: 'largeCoverImageUrl',
+          createdAt: 'createdAt',
+          surveyType: 'surveyType',
+        )
+      ];
+      when(mockGetCachedSurveysUseCase.call())
+          .thenAnswer((_) async => Success(cachedSurveys));
 
       container = ProviderContainer(overrides: [
         homeViewModelProvider.overrideWith((ref) => HomeViewModel(
               mockGetProfileUseCase,
               mockGetSurveysUseCase,
               mockSignOutUseCase,
+              mockGetCachedSurveysUseCase,
             )),
       ]);
       viewModel = container.read(homeViewModelProvider.notifier);
       addTearDown(() => container.dispose());
-    });
-
-    test('When initializing HomeViewModel, it emits Init state', () {
-      expect(container.read(homeViewModelProvider), const HomeViewState.init());
     });
 
     test('When calling init success, it emits Success state', () {

--- a/test/usecase/get_surveys_use_case_test.dart
+++ b/test/usecase/get_surveys_use_case_test.dart
@@ -21,7 +21,7 @@ void main() {
         () async {
       final expected = <SurveyModel>[];
       when(mockRepository.getSurveys(
-        number: 1,
+        pageNumber: 1,
         size: 10,
       )).thenAnswer((_) async => expected);
 
@@ -41,7 +41,7 @@ void main() {
       const expected = NetworkExceptions.unexpectedError();
 
       when(mockRepository.getSurveys(
-        number: 1,
+        pageNumber: 1,
         size: 10,
       )).thenAnswer((_) async => Future.error(expected));
 

--- a/test/usecase/sign_out_use_case_test.dart
+++ b/test/usecase/sign_out_use_case_test.dart
@@ -9,13 +9,20 @@ import '../mocks/generate_mocks.mocks.dart';
 void main() {
   group('SignOutUseCase', () {
     late MockAuthRepository mockRepository;
-    late MockAuthPersistence mockPersistence;
+    late MockAuthPersistence mockAuthPersistence;
+    late MockSurveyPersistence mockSurveyPersistence;
     late SignOutUseCase useCase;
 
     setUp(() {
       mockRepository = MockAuthRepository();
-      mockPersistence = MockAuthPersistence();
-      useCase = SignOutUseCase(mockRepository, mockPersistence);
+      mockAuthPersistence = MockAuthPersistence();
+      mockSurveyPersistence = MockSurveyPersistence();
+
+      useCase = SignOutUseCase(
+        mockRepository,
+        mockAuthPersistence,
+        mockSurveyPersistence,
+      );
     });
 
     test('When calling signOut successfully, it returns the result Success',
@@ -24,11 +31,13 @@ void main() {
         token: 'accessToken',
       )).thenAnswer((_) async => Future(() => null));
 
-      when(mockPersistence.accessToken).thenAnswer((_) async => 'accessToken');
+      when(mockAuthPersistence.accessToken)
+          .thenAnswer((_) async => 'accessToken');
 
       final result = await useCase.call();
 
-      verify(mockPersistence.clearAllStorage()).called(1);
+      verify(mockAuthPersistence.clearAllStorage()).called(1);
+      verify(mockSurveyPersistence.clear()).called(1);
       expect(result, isA<Success>());
     });
 
@@ -39,11 +48,13 @@ void main() {
         token: 'accessToken',
       )).thenAnswer((_) => Future.error(exception));
 
-      when(mockPersistence.accessToken).thenAnswer((_) async => 'accessToken');
+      when(mockAuthPersistence.accessToken)
+          .thenAnswer((_) async => 'accessToken');
 
       final result = await useCase.call();
 
-      verifyNever(mockPersistence.clearAllStorage());
+      verifyNever(mockAuthPersistence.clearAllStorage());
+      verifyNever(mockSurveyPersistence.clear());
       expect(result, isA<Failed>());
       expect((result as Failed).exception.actualException, exception);
     });

--- a/test_resource/fake_response/fake_surveys_response.json
+++ b/test_resource/fake_response/fake_surveys_response.json
@@ -9,7 +9,7 @@
         "thank_email_above_threshold": "Fake Thank Email Above Threshold",
         "thank_email_below_threshold": "Fake Thank Email Below Threshold",
         "is_active": true,
-        "cover_image_url": "https://example.com/fake-image.png",
+        "cover_image_url": "https://dhdbhh0jsld0o.cloudfront.net/m/1ea51560991bcb7d00d0_",
         "created_at": "2022-04-05T12:34:56Z",
         "active_at": "2022-04-05T12:34:56Z",
         "inactive_at": null,

--- a/test_resource/fake_response/fake_user_profile_response.json
+++ b/test_resource/fake_response/fake_user_profile_response.json
@@ -5,7 +5,7 @@
     "attributes": {
       "email": "fake_user_email@example.com",
       "name": "Fake User Name",
-      "avatar_url": "https://example.com/fake-avatar.png"
+      "avatar_url": "https://secure.gravatar.com/avatar/8fae17b9d0c4cca18a9661bcdf650f23"
     }
   }
 }


### PR DESCRIPTION
Close https://github.com/hoangnguyen92dn/survey-flutter-ic/issues/37

## What happened 👀

On the home screen, when the user swipes from top to bottom, the application must fetch the latest surveys and refresh the survey list.

- Support pull-down to refresh the list of surveys.
- Refresh the cache data.
- Show a loading indicator (implemented) while doing the refreshing.

## Insight 📝

- Setup hive to cache the surveys
- Display cached surveys on fetching error
- Add Pull to Refresh indicator
- Add UnitTest

Notice: The cache mechanism is for demonstration storing/retrieving data from Hive persistence. So the flow to display surveys from cached is simple like this:

`Home Page` > `Get Surveys from the cache` > `Get survey from API` >

- API success: Cache the surveys
- API error: If the cache contains surveys, show the surveys from the cache

## Proof Of Work 📹

https://user-images.githubusercontent.com/6950766/235067055-c4a4810d-3860-4833-b0f3-5ae541fb60bd.mp4
